### PR TITLE
Meshrdf klortho

### DIFF
--- a/web-ui/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/web-ui/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -48,7 +48,7 @@
   </rule>
 
   <!--
-    FIXME: I can't figure out how to do this with 303 instread of 302.  It might be
+    FIXME: I can't figure out how to do this with 303 instead of 302.  It might be
     better to do in the servlet.
   -->
   <rule>
@@ -63,11 +63,13 @@
     <to type="redirect" qsappend="false">$1.html</to>
   </rule>
 
+  <!-- mesh/D065609.html -->
   <rule>
     <from casesensitive="true">^/[DQMC].*\.html$</from>
     <to>/explore.jsp</to>
   </rule>
 
+  <!-- mesh/2015/D065609.html -->
   <rule>
     <from casesensitive="true">^/\d{4,4}/[DQMC].*\.html$</from>
     <to>/explore.jsp?resource_prefix=..%2F</to>
@@ -79,8 +81,9 @@
     <to>/servlet/explore?id=$1</to>
   </rule>
 
+  <!-- mesh/D015242.rdf, mesh/2015/D015242.n3, etc. -->
   <rule>
-    <from casesensitive="true">^/([DQMC]\d{4,})\.(.*)$</from>
+    <from casesensitive="true">^/((\d{4,4}\/)?[DQMC]\d{4,})\.(.*)$</from>
     <to>/servlet/explore?id=$1&amp;format=$2</to>
   </rule>
 

--- a/web-ui/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/web-ui/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -58,8 +58,19 @@
   </rule>
 
   <rule>
+    <condition name="Accept" type="header">text/html</condition>
+    <from casesensitive="true">^/\d{4,4}/([DQMC]\d{4,})$</from>
+    <to type="redirect" qsappend="false">$1.html</to>
+  </rule>
+
+  <rule>
     <from casesensitive="true">^/[DQMC].*\.html$</from>
-    <to>/explore.html</to>
+    <to>/explore.jsp</to>
+  </rule>
+
+  <rule>
+    <from casesensitive="true">^/\d{4,4}/[DQMC].*\.html$</from>
+    <to>/explore.jsp?resource_prefix=..%2F</to>
   </rule>
 
   <rule>
@@ -129,7 +140,7 @@
   <rule>
     <condition name="Accept" type="header">text/html</condition>
     <from casesensitive="true">/describe$</from>
-    <to>/explore.html</to>
+    <to>/explore.jsp</to>
   </rule>
 
 

--- a/web-ui/src/main/webapp/css/lode-style.css
+++ b/web-ui/src/main/webapp/css/lode-style.css
@@ -85,3 +85,13 @@ span.pagmes {
 
 }
 
+#error-div {
+  border: 2px solid red;
+  background-color: #FDD;
+  border-radius: 10px;
+}
+#error-div .alert {
+  color: #600;
+  font-style: italic;
+  font-size: 110%;
+}

--- a/web-ui/src/main/webapp/explore.jsp
+++ b/web-ui/src/main/webapp/explore.jsp
@@ -25,18 +25,38 @@
     <link data-require="bootstrap@*" data-semver="3.2.0" rel="stylesheet" 
         href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.css" />
 
+    <%
+      String rp = request.getParameter("resource_prefix");
+      String resourcePrefix = rp == null ? "" : rp;
+    %>
+    <!-- 
+      resourcePrefix = <%= resourcePrefix %>
+    -->
 
-    <link rel="stylesheet" href="css/lode-style.css" type="text/css" media="screen">
+    <link rel="stylesheet" href="<%= resourcePrefix %>css/lode-style.css" type="text/css" media="screen">
 
-    <script type="text/javascript" src="codemirror/codemirror.js"></script>
-    <script type="text/javascript" src="codemirror/sparql.js"></script>
-    <script type="text/javascript" src="scripts/namespaces.js"></script>
-    <script type="text/javascript" src="scripts/queries.js"></script>
-    <script type="text/javascript" src="scripts/lode.js"></script>
+    <script type="text/javascript" src="<%= resourcePrefix %>codemirror/codemirror.js"></script>
+    <script type="text/javascript" src="<%= resourcePrefix %>codemirror/sparql.js"></script>
+    <script type="text/javascript" src="<%= resourcePrefix %>scripts/namespaces.js"></script>
+    <script type="text/javascript" src="<%= resourcePrefix %>scripts/queries.js"></script>
+    <script type="text/javascript" src="<%= resourcePrefix %>scripts/lode.js"></script>
+
+    <link data-require="font-awesome@*" data-semver="4.2.0" rel="stylesheet" 
+        href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" />
+    <link href="<%= resourcePrefix %>css/style.css" rel="stylesheet" />
+
+    <!--[if lt IE 9]>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+  </head>
+
   </head>
 
 
-  <body onload="$('#data-explorer-content').explore({namespaces : lodeNamespacePrefixes});">
+  <body onload="$('#data-explorer-content').explore({
+      resource_prefix : '<%= resourcePrefix %>',
+      namespaces : lodeNamespacePrefixes
+    });">
     <div class="header"></div>
     <div class="container-fluid">
       <div id="meshTabContent" class="tab-content">
@@ -55,9 +75,9 @@
 
     <script>
       $(function() {
-        $(".header").load("header.html");
-        $(".navi").load("nav.html");
-        $(".footer").load("footer.html");
+        $(".header").load("<%= resourcePrefix %>header.html");
+        $(".navi").load("<%= resourcePrefix %>nav.html");
+        $(".footer").load("<%= resourcePrefix %>footer.html");
       });
     </script>
   </body>

--- a/web-ui/src/main/webapp/explore.jsp
+++ b/web-ui/src/main/webapp/explore.jsp
@@ -76,7 +76,9 @@
     <script>
       $(function() {
         $(".header").load("<%= resourcePrefix %>header.html");
-        $(".navi").load("<%= resourcePrefix %>nav.html");
+        $(".navi").load('<%= resourcePrefix %>nav.jsp?resource_prefix=<%= 
+          java.net.URLEncoder.encode(resourcePrefix, "UTF-8")
+        %>');
         $(".footer").load("<%= resourcePrefix %>footer.html");
       });
     </script>

--- a/web-ui/src/main/webapp/header.html
+++ b/web-ui/src/main/webapp/header.html
@@ -1,24 +1,3 @@
-<!--
-  Put these into the main layout file, now.  I [cfm] think they have to be loaded before
-  codemirror.
-
-    <link data-require="bootstrap-css" data-semver="3.2.0" rel="stylesheet" 
-        href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" />
-    <link data-require="bootstrap@*" data-semver="3.2.0" rel="stylesheet" 
-        href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.css" />
--->
-
-    <link data-require="font-awesome@*" data-semver="4.2.0" rel="stylesheet" 
-        href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" />
-    <link href="css/style.css" rel="stylesheet" />
-
-    <!--[if lt IE 9]>
-      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <script data-require="jquery" data-semver="2.1.1" src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-    <script data-require="bootstrap" data-semver="3.2.0" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.js"></script>
-  </head>
-
     <div class="container-fluid">
       <div class="row">
         <div class="col-md-9">

--- a/web-ui/src/main/webapp/index.html
+++ b/web-ui/src/main/webapp/index.html
@@ -36,6 +36,7 @@
         hashAddressBar: false, 
         shorten:false});
     </script>
+    <link rel='stylesheet' href='css/style.css' />
   </head>
 
   <body>

--- a/web-ui/src/main/webapp/index.html
+++ b/web-ui/src/main/webapp/index.html
@@ -92,7 +92,7 @@
       $(function() {
         $(".header").load("header.html");
         $(".footer").load("footer.html");
-        $(".navi").load("nav.html");
+        $(".navi").load("nav.jsp");
       });
     </script>
   </body>

--- a/web-ui/src/main/webapp/nav.jsp
+++ b/web-ui/src/main/webapp/nav.jsp
@@ -1,5 +1,9 @@
+<%
+  String rp = request.getParameter("resource_prefix");
+  String resourcePrefix = rp == null ? "" : rp;
+%>
 <ul class="nav nav-pills pull-right">
-  <li role="presentation"><a href="./sparql" target="_blank">SPARQL endpoint</a></li>
+  <li role="presentation"><a href="<%= resourcePrefix %>sparql" target="_blank">SPARQL endpoint</a></li>
   <li role="presentation"><a href="http://hhs.github.io/meshrdf/" target="_blank">Technical Docs</a></li>
   <li role="presentation"><a href="/mesh" role="button">MeSH RDF Home</a></li>
   <li role="presentation"><a href="http://www.nlm.nih.gov/mesh/" target="_blank">MeSH Home</a></li>

--- a/web-ui/src/main/webapp/query.html
+++ b/web-ui/src/main/webapp/query.html
@@ -34,6 +34,7 @@
     <script type="text/javascript" src="scripts/namespaces.js"></script>
     <script type="text/javascript" src="scripts/queries.js"></script>
     <script type="text/javascript" src="scripts/lode.js"></script>
+    <link rel='stylesheet' href='css/style.css' />
   </head>
 
   <body onload="$('#sparql-content').sparql({namespaces : lodeNamespacePrefixes, inference: true});">

--- a/web-ui/src/main/webapp/query.html
+++ b/web-ui/src/main/webapp/query.html
@@ -57,7 +57,7 @@
     <script>
       $(function() {
         $(".header").load("header.html");
-        $(".navi").load("nav.html");
+        $(".navi").load("nav.jsp");
         $(".footer").load("footer.html");
       });
     </script>

--- a/web-ui/src/main/webapp/scripts/lode.js
+++ b/web-ui/src/main/webapp/scripts/lode.js
@@ -94,8 +94,7 @@ function _parseOptions(options) {
         'namespaces' : {
             rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
             rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
-            owl: 'http://www.w3.org/2002/07/owl#',
-            mesh: 'http://id.nlm.nih.gov/mesh/'
+            owl: 'http://www.w3.org/2002/07/owl#'
         },
         'example_queries' : [],
         'default_resource_image_url': 'images/rdf_flyer.gif',
@@ -911,13 +910,22 @@ function _formatUnbound (node, varName) {
 }
 
 function _toQName (uri) {
-    for (prefix in loadstarNamespaces) {
+    // Find the *longest* match
+    var longest_match = '';
+    var prefix_match;
+    for (var prefix in loadstarNamespaces) {
         var nsURI = loadstarNamespaces[prefix];
-        if (uri.indexOf(nsURI) == 0) {
-            return prefix + ':' + uri.substring(nsURI.length);
+        if (uri.indexOf(nsURI) == 0 && nsURI.length > longest_match.length) {
+            longest_match = nsURI;
+            prefix_match = prefix;
         }
     }
-    return null;
+    if (typeof(prefix_match) !== 'undefined') {
+        return prefix_match + ':' + uri.substring(longest_match.length);
+    }
+    else {
+        return null;
+    }
 }
 
 function _toQNameOrURI (uri) {

--- a/web-ui/src/main/webapp/scripts/lode.js
+++ b/web-ui/src/main/webapp/scripts/lode.js
@@ -308,10 +308,10 @@ function _buildSparqlPage(element) {
 
 
     section1.append(
-        $("<p style='float: right;'></p>").append(
-            $("<label for='render'>Output: </label>"))
-            .append(
-            $("<select name='render' id='render'></select>")
+        $("<p style='float: right;'></p>")
+          .append( $("<label for='render'>Output: </label>") )
+          .append(
+              $("<select name='render' id='render'></select>")
                 .append('<option value="HTML">HTML</option>')
                 .append('<option value="XML">XML</option>')
                 .append('<option value="JSON">JSON</option>')
@@ -323,15 +323,24 @@ function _buildSparqlPage(element) {
         )
     );
 
+    var control_p = $("<p></p>");
+    section1.append(control_p);
+
     if (lodestarRdfsInference) {
-        section1.append(
-            $("<p></p>").append(
-                $("<label for='inference'>RDFS inference? </label>"))
-                .append(
-                $("<input type='checkbox' id='inference' name='inference' value='true'/>")
-            )
-        );
+        control_p
+          .append( $("<label for='inference'>RDFS inference? </label>") )
+          .append( $("<input type='checkbox' id='inference' name='inference' value='true'/>") )
+          .append("&#160;&#160;&#160;");
     }
+
+    control_p
+      .append( $("<label for='year'>Year</label>") )
+      .append(
+          $("<select name='year' id='year'></select>")
+              .append("<option value='current'>Current</option>")
+              .append("<option value='2015'>2015</option>")
+              .on("change", _fixQueryYear)
+      );
 
     section1.append(
         $("<p></p>").append(
@@ -869,9 +878,22 @@ function setExampleQueries() {
 
 }
 
+function _fixQueryYear() {
+    var year_val = $('#year').val();
+    var graph = 'http://id.nlm.nih.gov/mesh' + (year_val != 'current' ? '/' + year_val : '');
+    var prefix = 'mesh' + (year_val != 'current' ? year_val : '');
+
+    sparqlQueryTextArea.setValue(
+        sparqlQueryTextArea.getValue()
+            .replace(new RegExp("FROM\\s<http://id.nlm.nih.gov/mesh(/\\d+)?.*?>"), "FROM <" + graph + ">")
+            .replace(new RegExp("mesh(\\d+)?:(?!\\s)", "g"), prefix + ":")
+    );
+}
+
 function _setTextAreQuery(anchor) {
     var q = exampleQueries[anchor.id];
     sparqlQueryTextArea.setValue(_getPrefixes() + "\n" + q.query);
+    _fixQueryYear();
     // Turn inferencing on if needed, but don't turn it off if it's not
     if (q.hasOwnProperty("inferencing") && q.inferencing) {
         $('#inference').prop('checked', true);

--- a/web-ui/src/main/webapp/scripts/lode.js
+++ b/web-ui/src/main/webapp/scripts/lode.js
@@ -19,8 +19,9 @@
 /**
  * global variables
  */
-var loadestarQueryService;
-var loadstarExploreService;
+var lodestarResourcePrefix;
+var lodestarQueryService;
+var lodestarExploreService;
 var lodestarResultsPerPage;
 var lodestarIslogging;
 var lodestarDefaultQuery;
@@ -28,13 +29,13 @@ var lodestarVoidQuery;
 var lodestarRdfsInference;
 var lodestarDefaultResourceImg;
 
-var loadstarNamespaces = {};
+var lodestarNamespaces = {};
 var lodestarDefaultUriBase;
-var tableid = "loadstar-results-table";
+var tableid = "lodestar-results-table";
 
 var lodestarNextUrl;
-var loadstarPrevLink;   // true if 'prev' should be a hyperlink
-var loadstarPrevUrl;
+var lodestarPrevLink;   // true if 'prev' should be a hyperlink
+var lodestarPrevUrl;
 
 var sparqlQueryTextArea;
 
@@ -83,6 +84,7 @@ var sparqlQueryTextArea;
 function _parseOptions(options) {
 
     var _options = $.extend({
+        'resource_prefix': '',
         'servlet_base': 'servlet',
         'query_servlet_name': 'query',
         'explore_servlet_name': 'explore',
@@ -101,16 +103,17 @@ function _parseOptions(options) {
         'default_id_prefix': 'mesh'
     }, options);
 
-    loadestarQueryService = _options.servlet_base + "/" + _options.query_servlet_name;
-    loadstarExploreService = _options.servlet_base + "/" + _options.explore_servlet_name;
+    lodestarResourcePrefix = _options.resource_prefix;
+    lodestarQueryService = _options.resource_prefix + _options.servlet_base + "/" + _options.query_servlet_name;
+    lodestarExploreService = _options.resource_prefix + _options.servlet_base + "/" + _options.explore_servlet_name;
     lodestarResultsPerPage = _options.results_per_page;
     lodestarIslogging = _options.logging;
     lodestarRdfsInference = _options.inference;
     lodestarDefaultQuery = _options.default_query;
     lodestarVoidQuery = _options.void_query;
-    loadstarNamespaces = _options.namespaces;
-    lodestarDefaultResourceImg =  _options.default_resource_image_url;
-    lodestarDefaultUriBase = loadstarNamespaces[_options.default_id_prefix];
+    lodestarNamespaces = _options.namespaces;
+    lodestarDefaultResourceImg =  _options.resource_prefix + _options.default_resource_image_url;
+    lodestarDefaultUriBase = lodestarNamespaces[_options.default_id_prefix];
 
     if (lodestarIslogging) {
         $('#lode-log').show();
@@ -138,7 +141,7 @@ function _buildVoid(element) {
 
     $.ajax ( {
         type: 'GET',
-        url: loadestarQueryService + "?query=" + encodeURIComponent(voidSparql),
+        url: lodestarQueryService + "?query=" + encodeURIComponent(voidSparql),
         headers: {
             Accept: "application/sparql-results+json"
         },
@@ -247,7 +250,7 @@ function _buildExplorerPage(element) {
     $("#" + id).append('<hr/>')
     var downloadsSpan  = $("<span style='padding-left: 5px;'/>");
     var xmlimg = $('<img />');
-    xmlimg.attr('src', 'images/file_RDF_XML_small.gif');
+    xmlimg.attr('src', lodestarResourcePrefix + 'images/file_RDF_XML_small.gif');
     xmlimg.attr('alt', 'RDF/XML');
     xmlimg.attr('title', 'Show RDF/XML for this resource');
     xmlimg.attr('style','cursor:pointer')
@@ -256,7 +259,7 @@ function _buildExplorerPage(element) {
     });
 
     var n3img = $('<img />');
-    n3img.attr('src', 'images/file_RDF_N3_small.gif');
+    n3img.attr('src', lodestarResourcePrefix + 'images/file_RDF_N3_small.gif');
     n3img.attr('alt', 'RDF/N3');
     n3img.attr('title', 'Show RDF/N3 for this resource');
     n3img.attr('style','cursor:pointer')
@@ -265,7 +268,7 @@ function _buildExplorerPage(element) {
     });
 
     var jsonimg = $('<img />');
-    jsonimg.attr('src', 'images/file_RDF_JSONLD_small.jpg');
+    jsonimg.attr('src', lodestarResourcePrefix + 'images/file_RDF_JSONLD_small.jpg');
     jsonimg.attr('alt', 'RDF/JSON');
     jsonimg.attr('title', 'Show RDF/JSON for this resource');
     jsonimg.attr('style','cursor:pointer')
@@ -356,7 +359,7 @@ function _buildSparqlPage(element) {
     );
 
     section1.append("<div id='query-executing-spinner'>" +
-        "Executing query...&nbsp;<img src='images/loadingAnimation.gif'>" +
+        "Executing query...&nbsp;<img src='" + lodestarResourcePrefix + "images/loadingAnimation.gif'>" +
         "</div>");
 
     section2.append(
@@ -369,12 +372,12 @@ function _buildSparqlPage(element) {
 
     element.append(sparqlForm);
 
-    var resultsSection = $("<section id='loadstar-results-section' styname='results'></section>");
+    var resultsSection = $("<section id='lodestar-results-section' styname='results'></section>");
 
     resultsSection.append ("<div id='pagination' class='pagination-banner'></div>");
 
     resultsSection.append ("<div style='padding: 5px; width:99%;overflow: scroll;'>" +
-        "<table id='loadstar-results-table' class='table table-bordered table-hover'></tabel>" +
+        "<table id='lodestar-results-table' class='table table-bordered table-hover'></tabel>" +
         "</div>");
 
     console.info("calling element.append(resultsSection);");
@@ -475,13 +478,13 @@ function querySparql () {
                 };
             }
             else if (rendering.match(/RDF/)) {
-                location.href = loadestarQueryService + "?query=" + encodeURIComponent(querytext) + "&format=RDF/XML";
+                location.href = lodestarQueryService + "?query=" + encodeURIComponent(querytext) + "&format=RDF/XML";
             }
             else if (rendering.match(/JSON-LD/)) {
-                location.href = loadestarQueryService + "?query=" + encodeURIComponent(querytext) + "&format=JSON-LD";
+                location.href = lodestarQueryService + "?query=" + encodeURIComponent(querytext) + "&format=JSON-LD";
             }
             else if (rendering.match(/N3/)) {
-                location.href = loadestarQueryService + "?query=" + encodeURIComponent(querytext) + "&format=N3";
+                location.href = lodestarQueryService + "?query=" + encodeURIComponent(querytext) + "&format=N3";
             }
             else  {
                 displayError("You can only render graph queries in either HTML, RDF/XML, RDF/JSON or RDF/N3 format")
@@ -501,19 +504,19 @@ function querySparql () {
                 };
             }
             else if (rendering.match(/^XML/)) {
-                location.href = loadestarQueryService + "?query=" + 
+                location.href = lodestarQueryService + "?query=" + 
                   encodeURIComponent(querytext) + "&format=XML&limit=" + limit + "&offset=" + offset + "&inference=" + rdfs;
             }
             else if (rendering.match(/JSON$/)) {
-                location.href = loadestarQueryService + "?query=" + 
+                location.href = lodestarQueryService + "?query=" + 
                   encodeURIComponent(querytext) + "&format=JSON&limit=" + limit + "&offset=" + offset+ "&inference=" + rdfs;
             }
             else if (rendering.match(/CSV/)) {
-                location.href = loadestarQueryService + "?query=" + 
+                location.href = lodestarQueryService + "?query=" + 
                   encodeURIComponent(querytext) + "&format=CSV&limit=" + limit + "&offset=" + offset+ "&inference=" + rdfs;
             }
             else if (rendering.match(/TSV/)) {
-                location.href = loadestarQueryService + "?query=" + 
+                location.href = lodestarQueryService + "?query=" + 
                   encodeURIComponent(querytext) + "&format=TSV&limit=" + limit + "&offset=" + offset+ "&inference=" + rdfs;
             }
             else  {
@@ -528,7 +531,7 @@ function querySparql () {
     setNextPrevUrl(querytext, limit, offset, rdfs);
     $.ajax ( {
         type: 'GET',
-        url: loadestarQueryService + "?" + queryString,
+        url: lodestarQueryService + "?" + queryString,
         headers: {
             Accept: requestHeader
         },
@@ -548,10 +551,10 @@ function setNextPrevUrl (queryString, limit, offset, rdfs) {
                   "&inference=" + rdfs;
 
     lodestarNextUrl = qs_base + "&offset=" + (_offset + results_per_page);
-    loadstarPrevLink = _offset > 0;
-    if (loadstarPrevLink) {
+    lodestarPrevLink = _offset > 0;
+    if (lodestarPrevLink) {
         var prev_offset = _offset >= results_per_page ? _offset - results_per_page : 0;
-        loadstarPrevUrl = qs_base + "&offset=" + prev_offset;
+        lodestarPrevUrl = qs_base + "&offset=" + prev_offset;
     }
 }
 
@@ -595,7 +598,7 @@ function renderGraphQuery (graph, tableid) {
 
                     var linkSpan  = $('<span/>');
                     var img = $('<img />');
-                    img.attr('src', 'images/external_link.png');
+                    img.attr('src', lodestarResourcePrefix + 'images/external_link.png');
                     img.attr('alt', '^');
                     img.attr('title', 'Resolve URI on the web');
 
@@ -626,9 +629,9 @@ function renderGraphQuery (graph, tableid) {
 
 function displayPagination()  {
     var prevA;
-    if (loadstarPrevLink) {
+    if (lodestarPrevLink) {
         prevA = $('<a></a>');
-        prevA.attr('href',"?" + loadstarPrevUrl);
+        prevA.attr('href',"?" + lodestarPrevUrl);
         prevA.attr('class',"pag prev");
         prevA.text("Previous")
     }
@@ -769,7 +772,7 @@ function _formatURI (node, varName) {
 
     else if (node.value.match(/^(https?|ftp|mailto|irc|gopher|news):/)) {
         var img = $('<img />');
-        img.attr('src', 'images/external_link.png');
+        img.attr('src', lodestarResourcePrefix + 'images/external_link.png');
         img.attr('alt', '^');
         img.attr('title', 'Resolve URI on the web');
 
@@ -814,7 +817,7 @@ function _hrefBuilder(uri, label, internal) {
     if (!internal) {
         linkSpan.append('&nbsp;');
         var img = $('<img />');
-        img.attr('src', 'images/external_link.png');
+        img.attr('src', lodestarResourcePrefix + 'images/external_link.png');
         img.attr('alt', '^');
         img.attr('title', 'Resolve URI on the web');
 
@@ -913,8 +916,8 @@ function _toQName (uri) {
     // Find the *longest* match
     var longest_match = '';
     var prefix_match;
-    for (var prefix in loadstarNamespaces) {
-        var nsURI = loadstarNamespaces[prefix];
+    for (var prefix in lodestarNamespaces) {
+        var nsURI = lodestarNamespaces[prefix];
         if (uri.indexOf(nsURI) == 0 && nsURI.length > longest_match.length) {
             longest_match = nsURI;
             prefix_match = prefix;
@@ -968,14 +971,14 @@ function renderResourceTypes(element) {
         //var query = _getPrefixes() + uri;
 
         var loadingimg = $('<img />');
-        loadingimg.attr('src', 'images/ajax-loader.gif');
+        loadingimg.attr('src', lodestarResourcePrefix + 'images/ajax-loader.gif');
         loadingimg.attr('alt', '.');
         var loading = $('<p>Fetching resource type data...</p>').append(loadingimg);
         element.append(loading);
 
         $.ajax ( {
             type: 'GET',
-            url: loadstarExploreService + "/resourceTypes?uri=" + identifier,
+            url: lodestarExploreService + "/resourceTypes?uri=" + identifier,
             success: function (data){
 
                 loading.empty();
@@ -1036,14 +1039,14 @@ function renderAllResourceTypes(element, exclude) {
     if (queryString.match(/uri=/)) {
 
         var loadingimg = $('<img />');
-        loadingimg.attr('src', 'images/ajax-loader.gif');
+        loadingimg.attr('src', lodestarResourcePrefix + 'images/ajax-loader.gif');
         loadingimg.attr('alt', '.');
         var loading = $('<p>Fetching more resource type data...</p>').append(loadingimg);
         element.append(loading);
 
         $.ajax ( {
             type: 'GET',
-            url: loadstarExploreService + "/resourceAllTypes?" + queryString,
+            url: lodestarExploreService + "/resourceAllTypes?" + queryString,
             success: function (data){
 
                 var div = element;
@@ -1110,7 +1113,7 @@ function renderDepiction (element) {
     if (identifier) {
         $.ajax ( {
             type: 'GET',
-            url: loadstarExploreService + "/resourceDepictions?uri=" + identifier,
+            url: lodestarExploreService + "/resourceDepictions?uri=" + identifier,
             success: function (data){
 
                 var imgurl = lodestarDefaultResourceImg;
@@ -1137,14 +1140,14 @@ function renderShortDescription (element) {
         //uri = this._betterUnescape(queryString.match(/uri=([^&]*)/)[1]);
 
         var loadingimg = $('<img />');
-        loadingimg.attr('src', 'images/ajax-loader.gif');
+        loadingimg.attr('src', lodestarResourcePrefix + 'images/ajax-loader.gif');
         loadingimg.attr('alt', '.');
         var loading = $('<p>Fetching data...</p>').append(loadingimg);
         element.append(loading);
 
         $.ajax ( {
             type: 'GET',
-            url: loadstarExploreService + "/resourceShortDescription?uri=" + identifier,
+            url: lodestarExploreService + "/resourceShortDescription?uri=" + identifier,
             success: function (data){
                 loading.empty();
                 var div = element;
@@ -1199,7 +1202,7 @@ function renderTopRelatedObjects(p) {
 
         $.ajax ( {
             type: 'GET',
-            url: loadstarExploreService + "/resourceTopObjects?uri=" + identifier,
+            url: lodestarExploreService + "/resourceTopObjects?uri=" + identifier,
             success: function (data){
 
 //                var p = $("<p></p>");
@@ -1246,14 +1249,14 @@ function renderRelatedToObjects(element) {
         //uri = this._betterUnescape(queryString.match(/uri=([^&]*)/)[1]);
 
         var loadingimg = $('<img />');
-        loadingimg.attr('src', 'images/ajax-loader.gif');
+        loadingimg.attr('src', lodestarResourcePrefix + 'images/ajax-loader.gif');
         loadingimg.attr('alt', '.');
         var loading = $('<p>Fetching related to data...</p>').append(loadingimg);
         element.append(loading);
 
         $.ajax ( {
             type: 'GET',
-            url: loadstarExploreService + "/relatedToObjects?uri=" + identifier,
+            url: lodestarExploreService + "/relatedToObjects?uri=" + identifier,
             success: function (data){
 
                 loading.empty();
@@ -1352,14 +1355,14 @@ function renderRelatedFromSubjects(element) {
         //uri = this._betterUnescape(queryString.match(/uri=([^&]*)/)[1]);
 
         var loadingimg = $('<img />');
-        loadingimg.attr('src', 'images/ajax-loader.gif');
+        loadingimg.attr('src', lodestarResourcePrefix + 'images/ajax-loader.gif');
         loadingimg.attr('alt', '.');
         var loading = $('<p>Fetching related from data...</p>').append(loadingimg);
         element.append(loading);
 
         $.ajax ( {
             type: 'GET',
-            url: loadstarExploreService + "/relatedFromSubjects?uri=" + identifier,
+            url: lodestarExploreService + "/relatedFromSubjects?uri=" + identifier,
             success: function (data){
 
                 loading.empty();
@@ -1454,13 +1457,13 @@ function renderXML(uri) {
     var match_id = document.location.href.match(/\/([DQTMC][0-9]+)/);
     var idString = match_id ? match_id[1] : '';
     if ( idString ) {
-        location.href = loadstarExploreService + "?id=" + idString + "&format=rdf";
+        location.href = lodestarExploreService + "?id=" + idString + "&format=rdf";
     } else {
         var match_query = document.location.href.match(/\?(.*)/);
 		var queryString = match_query ? match_query[1] : '';
 		if (queryString.match(/uri=/)) {
             var param = this._betterUnescape(queryString.match(/uri=([^&]*)/)[1]);
-            location.href = loadestarQueryService + "?query=" + encodeURIComponent("describe<" + param + ">") + "&format=RDF/XML";
+            location.href = lodestarQueryService + "?query=" + encodeURIComponent("describe<" + param + ">") + "&format=RDF/XML";
         }
     }
 }
@@ -1469,13 +1472,13 @@ function renderN3(uri) {
     var match_id = document.location.href.match(/\/([DQTMC][0-9]+)/);
     var idString = match_id ? match_id[1] : '';
     if ( idString ) {
-        location.href = loadstarExploreService + "?id=" + idString + "&format=n3";
+        location.href = lodestarExploreService + "?id=" + idString + "&format=n3";
     } else {
         var match_query = document.location.href.match(/\?(.*)/);
 		var queryString = match_query ? match_query[1] : '';
 		if (queryString.match(/uri=/)) {
             var param = this._betterUnescape(queryString.match(/uri=([^&]*)/)[1]);
-            location.href = loadestarQueryService + "?query=" + encodeURIComponent("describe<" + param + ">") + "&format=N3";
+            location.href = lodestarQueryService + "?query=" + encodeURIComponent("describe<" + param + ">") + "&format=N3";
         }
     }
 }
@@ -1484,13 +1487,13 @@ function renderJson(uri) {
     var match_id = document.location.href.match(/\/([DQTMC][0-9]+)/);
     var idString = match_id ? match_id[1] : '';
     if ( idString ) {
-        location.href = loadstarExploreService + "?id=" + idString + "&format=json";
+        location.href = lodestarExploreService + "?id=" + idString + "&format=json";
     } else {
         var match_query = document.location.href.match(/\?(.*)/);
 		var queryString = match_query ? match_query[1] : '';
 		if (queryString.match(/uri=/)) {
             var param = this._betterUnescape(queryString.match(/uri=([^&]*)/)[1]);
-            location.href = loadestarQueryService + "?query=" + encodeURIComponent("describe<" + param + ">") + "&format=JSON-LD";
+            location.href = lodestarQueryService + "?query=" + encodeURIComponent("describe<" + param + ">") + "&format=JSON-LD";
         }
     }
 }
@@ -1499,15 +1502,15 @@ function renderJson(uri) {
 
 function _getPrefixes () {
     var prefixes = '';
-    for (prefix in this.loadstarNamespaces) {
-        var uri = this.loadstarNamespaces[prefix];
+    for (prefix in this.lodestarNamespaces) {
+        var uri = this.lodestarNamespaces[prefix];
         prefixes = prefixes + 'PREFIX ' + prefix + ': <' + uri + '>\n';
     }
     return prefixes;
 }
 
 function setNamespaces (namespaces) {
-    this.loadstarNamespaces = namespaces;
+    this.lodestarNamespaces = namespaces;
 }
 
 function _betterUnescape (s) {
@@ -1532,7 +1535,7 @@ function clearErrors() {
 
 function displaySparqlEndpoint() {
 
-    $("#sparql-endpoint-url").text(loadestarQueryService);
+    $("#sparql-endpoint-url").text(lodestarQueryService);
 }
 
 function reloadPage() {

--- a/web-ui/src/main/webapp/scripts/namespaces.js
+++ b/web-ui/src/main/webapp/scripts/namespaces.js
@@ -16,6 +16,7 @@ var lodeNamespacePrefixes = {
     xsd: 'http://www.w3.org/2001/XMLSchema#',
     owl: 'http://www.w3.org/2002/07/owl#',
     meshv: 'http://id.nlm.nih.gov/mesh/vocab#',
-    mesh: 'http://id.nlm.nih.gov/mesh/'
+    mesh: 'http://id.nlm.nih.gov/mesh/',
+    mesh2015: 'http://id.nlm.nih.gov/mesh/2015/'
 };
 


### PR DESCRIPTION
The changers here are mostly for [mesh-rdf#130](https://github.com/HHS/mesh-rdf/issues/130). You can check them out at http://iddev.nlm.nih.gov/klortho.  Here are some highlights:

* Error messages now stand out more.  E.g. [here](http://iddev.nlm.nih.gov/klortho/sparql?query=PRE&render=HTML&year=current&limit=50&offset=0#lodestart-sparql-results)
* Queries against the "latest year" (e.g. 2015, as opposed to the "current") work; e.g. [here](http://iddev.nlm.nih.gov/klortho/sparql?query=PREFIX+rdf%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%3E%0D%0APREFIX+rdfs%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23%3E%0D%0APREFIX+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%0D%0APREFIX+owl%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23%3E%0D%0APREFIX+meshv%3A+%3Chttp%3A%2F%2Fid.nlm.nih.gov%2Fmesh%2Fvocab%23%3E%0D%0APREFIX+mesh%3A+%3Chttp%3A%2F%2Fid.nlm.nih.gov%2Fmesh%2F%3E%0D%0APREFIX+mesh2015%3A+%3Chttp%3A%2F%2Fid.nlm.nih.gov%2Fmesh%2F2015%2F%3E%0D%0A%0D%0ASELECT+*+%0D%0AFROM+%3Chttp%3A%2F%2Fid.nlm.nih.gov%2Fmesh%2F2015%3E%0D%0AWHERE+%7B%0D%0A++mesh2015%3AD015242+meshv%3ApharmacologicalAction+%3Fpa+.%0D%0A++%3Fpa+rdfs%3Alabel+%3FpaLabel+.%0D%0A%7D+%0D%0A&render=HTML&year=2015&limit=50&offset=0#lodestart-sparql-results)
* URIs with the year will now resolve.  For example, [http://id.nlm.nih.gov/mesh/2015/D065609](http://iddev.nlm.nih.gov/klortho/2015/D065609).  These should work in all the various output formats (REST interface).
* The [SPARQL page](http://iddev.nlm.nih.gov/klortho/sparql) now has a "year" control, to let you switch the currently displayed query between "latest" and "current".
