### PR TITLE
Get most things working in Internet Explorer 11

### DIFF
--- a/web-ui/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/web-ui/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -18,6 +18,7 @@
 
   <!-- for testing
   <rule>
+    <name>foo-example</name>
     <from casesensitive="true">^/foo$</from>
     <to>/servlet/explore</to>
   </rule>
@@ -29,6 +30,7 @@
     then direct it to the query servlet.
   -->
   <rule>
+    <name>sparql-to-servlet-1</name>
     <condition type='query-string'>format=</condition>
     <condition name="format" type="parameter" operator="notequal">HTML</condition>
     <from casesensitive="true">^/sparql(.*)$</from>
@@ -36,13 +38,15 @@
   </rule>
 
   <rule>
-    <condition name="Accept" type="header">text/html</condition>
+    <name>sparql-to-jsp-1</name>
+    <condition name="Accept" type="header">(text/html|\*/\*)</condition>
     <from casesensitive="true">^/sparql$</from>
     <to last='true'>/query.jsp</to>
   </rule>
 
   <rule>
-    <condition name="Accept" type="header" operator="notequal">text/html</condition>
+    <name>sparql-to-servlet-2</name>
+    <condition name="Accept" type="header" operator="notequal">(text/html|\*/\*)</condition>
     <from casesensitive="true">^/sparql(.*)$</from>
     <to>/servlet/query$1</to>
   </rule>
@@ -52,38 +56,51 @@
     better to do in the servlet.
   -->
   <rule>
-    <condition name="Accept" type="header">text/html</condition>
+    <name>token-redirect-html-1</name>
+    <condition name="Accept" type="header">(text/html|\*/\*)</condition>
     <from casesensitive="true">^/([DQMC]\d{4,}(Q\d{4,})?)$</from>
     <to type="redirect" qsappend="false">$1.html</to>
   </rule>
 
   <rule>
-    <condition name="Accept" type="header">text/html</condition>
+    <name>token-redirect-html-2</name>
+    <condition name="Accept" type="header">(text/html|\*/\*)</condition>
     <from casesensitive="true">^/\d{4,4}/([DQMC]\d{4,}(Q\d{4,})?)$</from>
     <to type="redirect" qsappend="false">$1.html</to>
   </rule>
 
   <!-- mesh/D065609.html -->
   <rule>
+    <name>token-html-to-explore-jsp-1</name>
     <from casesensitive="true">^/[DQMC].*\.html$</from>
     <to>/explore.jsp</to>
   </rule>
 
   <!-- mesh/2015/D065609.html -->
   <rule>
+    <name>token-html-to-explore-jsp-2</name>
     <from casesensitive="true">^/\d{4,4}/[DQMC]\d{4,}(Q\d{4,})?\.html$</from>
     <to>/explore.jsp?resource_prefix=..%2F</to>
   </rule>
 
   <rule>
-    <condition name="Accept" type="header" operator="notequal">text/html</condition>
+    <name>token-to-explore-servlet-1</name>
+    <condition name="Accept" type="header" operator="notequal">(text/html|\*/\*)</condition>
     <from casesensitive="true">^/([DQMC]\d{4,}(Q\d{4,})?)$</from>
     <to>/servlet/explore?id=$1</to>
   </rule>
 
-  <!-- mesh/D015242.rdf, mesh/2015/D015242.n3, etc. -->
+  <!-- mesh/D015242.rdf, etc. - we have to make sure $2 is the extension -->
   <rule>
-    <from casesensitive="true">^/((\d{4,4}\/)?[DQMC]\d{4,}(Q\d{4,})?)\.(.*)$</from>
+    <name>token-to-explore-servlet-2</name>
+    <from casesensitive="true">^/([DQMC]\d{4,}Q?\d{4,}?)\.(.*)$</from>
+    <to>/servlet/explore?id=$1&amp;format=$2</to>
+  </rule>
+
+  <!-- mesh/2015/D015242.rdf, etc. - we have to make sure $2 is the extension -->
+  <rule>
+    <name>token-to-explore-servlet-3</name>
+    <from casesensitive="true">^/(\d{4,4}/[DQMC]\d{4,}Q?\d{4,}?)\.(.*)$</from>
     <to>/servlet/explore?id=$1&amp;format=$2</to>
   </rule>
 
@@ -91,31 +108,35 @@
     to be fixed tree number
   -->
   <rule>
-      <condition name="Accept" type="header">text/html</condition>
+      <name>describe-token-1</name>
+      <condition name="Accept" type="header">(text/html|\*|\*)</condition>
       <from casesensitive="true">^/([ABCDEFGHIJKLMNVZ]\d{2}(?:\.\d+)*)(?:\.html|\.htm)?$</from>
       <to type="redirect">http://id.nlm.nih.gov/mesh/describe?uri=http://id.nlm.nih.gov/mesh/$1</to>
   </rule>
 
   <rule>
-      <condition name="Accept" type="header" operator="notequal">text/html</condition>
+      <name>describe-token-2</name>
+      <condition name="Accept" type="header" operator="notequal">(text/html|\*/\*)</condition>
       <from casesensitive="true">^/([ABCDEFGHIJKLMNVZ]\d{2}(?:\.\d+)*)$</from>
       <to>/servlet/explore?id=$1</to>
   </rule>
 
   <rule>
+      <name>describe-token-3</name>
       <from casesensitive="true">^/([ABCDEFGHIJKLMNVZ]\d{2}(?:\.\d+)*)\.(.*)$</from>
       <to>/servlet/explore?id=$1&amp;format=$2</to>
   </rule>
 
 
-
   <rule>
+    <name>vocab-to-ttl-file</name>
     <from casesensitive="true">^/vocab.*$</from>
     <to type="redirect">http://id.nlm.nih.gov/mesh/schema.owl</to> 
   </rule>
 
 <!--
     <rule>
+      <name>commented-1</name>
       <condition type="method" operator='equal'>POST</condition>
       <from casesensitive="true">/sparql$</from>
       <to last="true">/servlet/query$1</to>
@@ -125,12 +146,14 @@
 
 <!--
     <rule>
+        <name>commented-2</name>
         <condition name="Accept" type="header">application/sparql.*</condition>
         <from casesensitive="true">/sparql(.*)$</from>
         <to>/servlet/query$1</to>
     </rule>
 
     <rule>
+        <name>commented-3</name>
         <condition name="Accept" type="header">text/*</condition>
         <from casesensitive="true">/sparql(.*)$</from>
         <to>/servlet/query$1</to>
@@ -141,20 +164,23 @@
 
 
   <rule>
-    <condition name="Accept" type="header">text/html</condition>
+    <name>describe-to-explore-jsp-1</name>
+    <condition name="Accept" type="header">(text/html|\*/\*)</condition>
     <from casesensitive="true">/describe$</from>
     <to>/explore.jsp</to>
   </rule>
 
 
   <rule>
-    <condition name="Accept" type="header" operator="notequal">text/html</condition>
+    <name>describe-to-explore-servlet-1</name>
+    <condition name="Accept" type="header" operator="notequal">(text/html|\*/\*)</condition>
     <from casesensitive="true">/describe(.*)$</from>
     <to>/servlet/explore$1</to>
   </rule>
 
 <!--
     <rule>
+        <name>commented-4</name>
         <condition name="Accept" type="header">application/rdf.*</condition>
         <from casesensitive="true">/describe(.*)$</from>
         <to>/servlet/explore$1</to>
@@ -172,12 +198,14 @@
       added.  The extension depends on the value of the "Accept" header.
 
     <rule>
+      <name>commented-5</name>
       <condition name="Accept" type="header">application/rdf+xml</condition>
       <from casesensitive="true">/depict/([^.]*)$</from>
       <to type="redirect" qsappend="false">$1.rdf</to>
     </rule>
 
     <rule>
+      <name>commented-6</name>
       <condition name="Accept" type="header">application/json</condition>
       <from casesensitive="true">/depict/([^.]*)$</from>
       <to type="redirect" qsappend="false">$1.json</to>
@@ -188,6 +216,7 @@
       Now handle the URLs that have extensions.  First, ".html" - it is special, because it's
       handled by the static html page, which then uses JS to make a pretty display.
     <rule>
+      <name>commented-7</name>
       <from casesensitive="true">/depict/(.*).html</from>
       <to>/depict.html</to>
     </rule>
@@ -197,6 +226,7 @@
       Next, any other URL that has an extension will get passed to the depict servlet for
       processing.
     <rule>
+      <name>commented-8</name>
       <from casesensitive="true">/depict/(.*)\.(.*)$</from>
       <to>/servlet/explore?id=$1&amp;format=$2</to>
     </rule>

--- a/web-ui/src/main/webapp/error.jsp
+++ b/web-ui/src/main/webapp/error.jsp
@@ -29,7 +29,6 @@
           href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.css" />
     <script data-require="bootstrap" data-semver="3.2.0" src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="css/lode-style.css" />
     <script type="text/javascript">var switchTo5x=true;</script>
     <script type="text/javascript" src="http://w.sharethis.com/button/buttons.js"></script>
     <script type="text/javascript">

--- a/web-ui/src/main/webapp/explore.jsp
+++ b/web-ui/src/main/webapp/explore.jsp
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
     <meta name="author" content="" />
+    <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE" />
 
     <!--[if lt IE 9]>
       <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
@@ -22,9 +23,9 @@
     -->
 
     <link data-require="bootstrap-css" data-semver="3.2.0" rel="stylesheet" 
-        href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" />
+          href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" />
     <link data-require="bootstrap@*" data-semver="3.2.0" rel="stylesheet" 
-        href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.css" />
+          href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.css" />
     <script data-require="bootstrap" data-semver="3.2.0" src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.js"></script>
 
     <%

--- a/web-ui/src/main/webapp/index.jsp
+++ b/web-ui/src/main/webapp/index.jsp
@@ -25,7 +25,7 @@
     <link data-require="bootstrap-css" data-semver="3.2.0" rel="stylesheet" 
           href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" />
     <link data-require="bootstrap@*" data-semver="3.2.0" rel="stylesheet" 
-          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.css" />
+          href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.css" />
     <script data-require="bootstrap" data-semver="3.2.0" src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.js"></script>
 
     <script type="text/javascript">var switchTo5x=true;</script>

--- a/web-ui/src/main/webapp/query.jsp
+++ b/web-ui/src/main/webapp/query.jsp
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="" />
     <meta name="author" content="" />
+    <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE" />
 
     <!--[if lt IE 9]>
       <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
@@ -22,11 +23,10 @@
     -->
 
     <link data-require="bootstrap-css" data-semver="3.2.0" rel="stylesheet" 
-        href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" />
+          href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" />
     <link data-require="bootstrap@*" data-semver="3.2.0" rel="stylesheet" 
-        href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.css" />
+          href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.css" />
     <script data-require="bootstrap" data-semver="3.2.0" src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.js"></script>
-
 
     <link rel="stylesheet" type="text/css" href="css/lode-style.css" />
     <link rel="stylesheet" type="text/css" href="codemirror/codemirror.css" />


### PR DESCRIPTION
- Add a <name> tag within each <rule> in urlrewrite.xml   This assists
  debugging when web.xml is altered to enable tuckey debugging output.
  So, it addreses HHS/mesh-rdf#47.
- Change each <condition> on "Accept" header to use expression (text/html|\*|\*)
  because IE no longer includes text/html in the Accept header.
- Change urlrewrite rules for .rdf, .nt, and .json-ld so that $2 is always
  the extension.  This helps HHS/mesh-rdf#84 but does not fully resolve the issue
  because all files download as "query".
- Make <head> section of index.jsp, query.jsp, explore.jsp, and explore.jsp consistent.
  The part of this that makes IE11 work is
  <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE" />