### PR TITLE
Resolve HHS/mesh-rdf#84

### DIFF
--- a/web-ui/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/web-ui/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -93,14 +93,28 @@
   <!-- mesh/D015242.rdf, etc. - we have to make sure $2 is the extension -->
   <rule>
     <name>token-to-explore-servlet-2</name>
-    <from casesensitive="true">^/([DQMC]\d{4,}Q?\d{4,}?)\.(.*)$</from>
+    <from casesensitive="true">^/([DQMC]\d{4,})\.(.*)$</from>
     <to>/servlet/explore?id=$1&amp;format=$2</to>
   </rule>
 
   <!-- mesh/2015/D015242.rdf, etc. - we have to make sure $2 is the extension -->
   <rule>
     <name>token-to-explore-servlet-3</name>
-    <from casesensitive="true">^/(\d{4,4}/[DQMC]\d{4,}Q?\d{4,}?)\.(.*)$</from>
+    <from casesensitive="true">^/(\d{4,4}\/[DQMC]\d{4,})\.(.*)$</from>
+    <to>/servlet/explore?id=$1&amp;format=$2</to>
+  </rule>
+
+  <!-- mesh/D015242Q000378.rdf, etc. - we have to make sure $2 is the extension -->
+  <rule>
+    <name>descqual-to-explore-servlet-1</name>
+    <from casesensitive="true">^/([DQMC]\d{4,}Q\d{4,})\.(.*)$</from>
+    <to>/servlet/explore?id=$1&amp;format=$2</to>
+  </rule>
+
+  <!-- mesh/2015/D015242Q000378.rdf, etc. - we have to make sure $2 is the extension -->
+  <rule>
+    <name>descqual-to-explore-servlet-2</name>
+    <from casesensitive="true">^/(\d{4,4}\/[DQMC]\d{4,}Q\d{4,})\.(.*)$</from>
     <to>/servlet/explore?id=$1&amp;format=$2</to>
   </rule>
 

--- a/web-ui/src/main/webapp/scripts/lode.js
+++ b/web-ui/src/main/webapp/scripts/lode.js
@@ -1134,6 +1134,31 @@ function getIdentifier(href) {
     }
 }
 
+/**
+ * This returns a relative identifier based on the url of this page and the uri.   
+ * It goes farther than getIdentifier() in that it should stay within the current system.
+ */
+function getRelativeIdentifier(href) {
+    // $2 - the first path segment
+    // $3 - the rest of the path excluding any extension
+    var relpath = href.match(/\/\/([^\/]+)\/([^\/]+)\/([^\.]+)/);
+    var hasQueryString = href.match(/\?(.*)/);
+    if (hasQueryString) {
+        var queryString = hasQueryString[1];
+        var uriMatch = queryString.match(/uri=([^&]+)/);
+        if (uriMatch) {
+            var canonical = uriMatch[1].replace(/%3A/g, ':').replace(/%2F/g, '/');
+            return canonical.replace(/^https?:\/\/[^\/]+\/[^\/]+/, '/'+relpath[2]);
+        }
+    } 
+    else if (relpath) {
+        return '/'+relpath[2]+'/'+relpath[3];
+    } 
+    else {
+        return null;
+    }
+}
+
 function renderDepiction (element) {
     var identifier = getIdentifier(document.location.href);
 

--- a/web-ui/src/main/webapp/scripts/lode.js
+++ b/web-ui/src/main/webapp/scripts/lode.js
@@ -253,38 +253,36 @@ function _buildExplorerPage(element) {
 
     $("#" + id).append('<hr/>')
     var downloadsSpan  = $("<span style='padding-left: 5px;'/>");
+
+    var relid = getRelativeIdentifier(document.location.href);
+    var xmllink = $('<a href="'+relid+'.rdf" />');
     var xmlimg = $('<img />');
     xmlimg.attr('src', lodestarResourcePrefix + 'images/file_RDF_XML_small.gif');
     xmlimg.attr('alt', 'RDF/XML');
     xmlimg.attr('title', 'Show RDF/XML for this resource');
-    xmlimg.attr('style','cursor:pointer')
-    xmlimg.click(function () {
-        renderXML();
-    });
+    xmllink.append(xmlimg);
 
+    var n3link = $('<a href="'+relid+'.n3" />');
     var n3img = $('<img />');
     n3img.attr('src', lodestarResourcePrefix + 'images/file_RDF_N3_small.gif');
     n3img.attr('alt', 'RDF/N3');
     n3img.attr('title', 'Show RDF/N3 for this resource');
     n3img.attr('style','cursor:pointer')
-    n3img.click(function () {
-        renderN3();
-    });
+    n3link.append(n3img);
 
+    var jsonlink = $('<a href="'+relid+'.json-ld" />');
     var jsonimg = $('<img />');
     jsonimg.attr('src', lodestarResourcePrefix + 'images/file_RDF_JSONLD_small.jpg');
     jsonimg.attr('alt', 'RDF/JSON');
     jsonimg.attr('title', 'Show RDF/JSON for this resource');
     jsonimg.attr('style','cursor:pointer')
-    jsonimg.click(function () {
-        renderJson();
-    });
+    jsonlink.append(jsonimg);
 
-    downloadsSpan.append(xmlimg);
+    downloadsSpan.append(xmllink);
     downloadsSpan.append("&nbsp;&nbsp;");
-    downloadsSpan.append(n3img);
+    downloadsSpan.append(n3link);
     downloadsSpan.append("&nbsp;&nbsp;");
-    downloadsSpan.append(jsonimg);
+    downloadsSpan.append(jsonlink);
     $("#" + id).append(downloadsSpan);
 }
 


### PR DESCRIPTION
- Add front-end function getRelativeIdentifier() that preserves the potentially developer-specific relative URI for an explore identifier.
- Use that to change front-end to produce relative links to the download formats, e.g. the relative identifier with the appropriate extension.
- Change back-end urlrewrite.xml to work properly.