### PR TITLE
Removing dates and links

### DIFF
--- a/web-ui/src/main/webapp/internal/footer.html
+++ b/web-ui/src/main/webapp/internal/footer.html
@@ -16,9 +16,6 @@
         <img src="https://www.nlm.nih.gov/images/usagov_logo.gif" alt="USA.gov logo"/>
       </a>
     </div>    
-    <div class="col-md-5 small">
-      <strong>Last reviewed:</strong> 16 September 2015<br><strong>Last updated:</strong> 16 September 2015<br><strong>First published:</strong>  10 October 2014<br><a href="https://www.nlm.nih.gov/cgi/viewMeta.pl?url=http://www.nlm.nih.gov/mesh/2014/mesh_browser/mbinfo.html&amp;description=full" onclick="javascript:openPopup('https://www.nlm.nih.gov/cgi/viewMeta.pl?url=https://www.nlm.nih.gov/mesh/2014/mesh_browser/mbinfo.html&amp;description=full'); return false;"><strong>Metadata</strong></a>| <a href="https://www.nlm.nih.gov/permlevels.html" onclick="javascript:openPopup('/permlevels.html');return false;"><strong>Permanence level</strong></a><strong>:</strong> Permanent: Dynamic Content
-    </div>
   </div>
 </footer>
 <!-- END internal/footer.html -->


### PR DESCRIPTION
Dates and links in the footer were copied over from the Teamsite template. Probably should have been left out. Displays on every page. 