### PR TITLE
Use no argument constructor for VirtuosoDataSourceProvider

### DIFF
--- a/web-ui/src/main/webapp/WEB-INF/ebi-lode-service.xml
+++ b/web-ui/src/main/webapp/WEB-INF/ebi-lode-service.xml
@@ -25,10 +25,7 @@
         <constructor-arg ref="virtuosoDataSourceProvider"/>
     </bean>
 
-    <bean id="virtuosoDataSourceProvider" class="uk.ac.ebi.fgpt.lode.impl.VirtuosoDatasourceProvider">
-        <constructor-arg name="endpointUrl" value="${lode.sparqlendpoint.url}"/>
-        <constructor-arg name="port" value="${lode.sparqlendpoint.port}"/>
-    </bean>
+    <bean id="virtuosoDataSourceProvider" class="uk.ac.ebi.fgpt.lode.impl.VirtuosoDatasourceProvider"/>
 
 
     <!-- An alterate datasource provider that doesn't require JNDI -->


### PR DESCRIPTION
- Addresses HHS/mesh-rdf#225.
- Removes dependence on system properties.
- Makes Lodestar believe the resource in the Tomcat container completely.