### PR TITLE
NLM changes for lodestar base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 target/
 out
 *~
+.settings/

--- a/lode-core-api/src/main/java/uk/ac/ebi/fgpt/lode/utils/GraphQueryFormats.java
+++ b/lode-core-api/src/main/java/uk/ac/ebi/fgpt/lode/utils/GraphQueryFormats.java
@@ -7,19 +7,25 @@ package uk.ac.ebi.fgpt.lode.utils;
  */
 public enum GraphQueryFormats {
 
-    RDFXML ("RDF/XML"),
-    N3 ("N3"),
-    JSON ("JSON-LD"),
-    TURTLE ("TURTLE");
+    RDFXML ("RDF/XML", "application/rdf+xml"),
+    N3 ("N3", "application/rdf+n3"),
+    JSON ("JSON-LD", "application/rdf+json"),
+    TURTLE ("TURTLE", "text/turtle");
 
     private final String format;
+    private final String mimetype;
 
-    private GraphQueryFormats(final String format) {
-        this.format = format;
+    private GraphQueryFormats(final String format, final String mimetype) {
+	this.format = format;
+	this.mimetype = mimetype;
     }
 
     @Override
     public String toString() {
         return format;
+    }
+
+    public String toMimeType() {
+        return mimetype;
     }
 }

--- a/lode-core-api/src/main/java/uk/ac/ebi/fgpt/lode/utils/TupleQueryFormats.java
+++ b/lode-core-api/src/main/java/uk/ac/ebi/fgpt/lode/utils/TupleQueryFormats.java
@@ -8,20 +8,26 @@ package uk.ac.ebi.fgpt.lode.utils;
 public enum TupleQueryFormats{
 
 
-    XML ("XML"),
-    CSV ("CSV"),
-    TSV ("TSV"),
-    JSON ("JSON");
+    XML ("XML", "application/sparql-results+xml"),
+    CSV ("CSV", "text/csv"),
+    TSV ("TSV", "text/tab-separated-values"),
+    JSON ("JSON", "application/sparql-results+json");
 
 
     private final String format;
+    private final String mimetype;
 
-    private TupleQueryFormats(String format) {
+    private TupleQueryFormats(String format, String mimetype) {
         this.format = format;
+	this.mimetype = mimetype;
     }
 
     @Override
     public String toString() {
         return format;
+    }
+
+    public String toMimeType() {
+	return mimetype;
     }
 }

--- a/lode-core-servlet/src/main/java/uk/ac/ebi/fgpt/lode/servlet/ExplorerServlet.java
+++ b/lode-core-servlet/src/main/java/uk/ac/ebi/fgpt/lode/servlet/ExplorerServlet.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.bind.annotation.*;
 import uk.ac.ebi.fgpt.lode.exception.LodeException;
 import uk.ac.ebi.fgpt.lode.model.ShortResourceDescription;
@@ -229,7 +230,26 @@ public class ExplorerServlet {
             describeResourceAsJson(uri, response);
         }
         else {
-	    describeResourceAsNtriples(uri, response);
+            describeResourceAsNtriples(uri, response);
+        }
+    }
+
+    @RequestMapping(value = "/html", method = RequestMethod.GET)
+    public ModelAndView describeResourceAsHtml(
+            @RequestParam(value = "uri", required = true ) String uri,
+            @RequestParam(value = "resource_prefix", required = false) String resource_prefix) throws LodeException {
+        URI absuri = resolveUri(uri);
+        if (absuri != null) {
+            ModelAndView mv = new ModelAndView();
+            mv.setViewName("explore");
+            if (resource_prefix == null) {
+                resource_prefix = "";
+            }
+            mv.addObject("uri", absuri.toString());
+            mv.addObject("resource_prefix", resource_prefix);
+            return mv;
+        } else {
+            throw new LodeException("Malformed or empty URI request: " + uri);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.springframework.version>3.2.2.RELEASE</org.springframework.version>
-        <org.slf4j.version>1.6.4</org.slf4j.version>
+        <org.slf4j.version>1.7.12</org.slf4j.version>
+        <log4j.version>1.2.17</log4j.version>
     </properties>
 
 
@@ -132,7 +133,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
+            <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -160,7 +161,7 @@
             <dependency>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
-                <version>1.2.16</version>
+                <version>${log4j.version}</version>
                 <scope>test</scope>
                 <!-- override test scope if required for CLI, webapp modules -->
             </dependency>

--- a/web-ui/pom.xml
+++ b/web-ui/pom.xml
@@ -23,8 +23,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
-
+            <version>${log4j.version}</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -35,6 +34,22 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- NOTE: Tomcat 7 is providing JSP API 3.0; be careful -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- NOTE: Tomcat 7 is providing JSP API 2.2; be careful -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jsp-api</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>ebi-lode</groupId>
             <artifactId>lode-core-servlet</artifactId>
@@ -42,9 +57,9 @@
         </dependency>
 
         <dependency>
-        <groupId>org.tuckey</groupId>
-        <artifactId>urlrewritefilter</artifactId>
-        <version>4.0.3</version>
+            <groupId>org.tuckey</groupId>
+            <artifactId>urlrewritefilter</artifactId>
+            <version>4.0.3</version>
         </dependency>
 
     </dependencies>

--- a/web-ui/src/main/webapp/WEB-INF/ebi-lode-service.xml
+++ b/web-ui/src/main/webapp/WEB-INF/ebi-lode-service.xml
@@ -12,6 +12,11 @@
 
     <bean name="explorerConfig" class="uk.ac.ebi.fgpt.lode.impl.DefaultExplorerViewConfigImpl"/>
 
+    <!--
+      NOTE: This bean is not really used.   The Spring MVC DispatcherServlet loads looks
+      at lode-servlet.xml, it is the child context, and is getting an autowired bean.
+      Probably don't much in ebi-lode-service.xml
+     -->
     <bean id="serviceServlet" class="uk.ac.ebi.fgpt.lode.servlet.ExplorerServlet">
         <property name="sparqlService" ref="jenaSparqlService"/>
         <property name="configuration" ref="explorerConfig"/>

--- a/web-ui/src/main/webapp/WEB-INF/lode-servlet.xml
+++ b/web-ui/src/main/webapp/WEB-INF/lode-servlet.xml
@@ -11,6 +11,9 @@
        http://www.springframework.org/schema/mvc
        http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
 
+    <!-- Load properties from lode.properties -->
+    <context:property-placeholder location="classpath:lode.properties"/>
+
     <!-- autowire this context only (just controllers, not services) based on annotations -->
     <context:annotation-config />
 

--- a/web-ui/src/main/webapp/WEB-INF/web.xml
+++ b/web-ui/src/main/webapp/WEB-INF/web.xml
@@ -1,19 +1,16 @@
-<!DOCTYPE web-app PUBLIC
-        "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-        "http://java.sun.com/dtd/web-app_2_3.dtd" >
-
-<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="
-         http://java.sun.com/xml/ns/j2ee
-         http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-         version="2.4">
+         http://java.sun.com/xml/ns/javaee
+         http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
     <display-name>EBI - Linked Data Explorer</display-name>
 
 
     <description>
         SPARQL endpoint and Linked Data Browser
     </description>
+
     <!--Define configuration to load-->
     <context-param>
         <param-name>contextConfigLocation</param-name>


### PR DESCRIPTION
These changes are designed to accomplish the following:

* Improve MIME type handling for each graph and tuple format, by:
   - centralizing these MIME types into the enums for the graph and tuple formats
   - adding a charset UTF-8 on each format
   - The MIME type must then be taken from the enum by the `SparqlServlet`.
* Enhance the `ExplorerServlet` to allow use of both JSPs and relative URIs fo assets when `lode.js` is customized to send a `resource_prefix` parameter derived using a baseURI.
* Enhance the `ExplorerServlet` so that the `uri` parameter given to many methods may be a relative URI resolved against a baseURI provided by the Spring configuration.
* Enhance the `ExplorerServlet` to add support for different formats such as RDF/XML using semantic URLs ending in `.rdf` or `.xml` in addition to using the `Accept` request header.
* Update the dependencies a bit to:
    - Assume Tomcat 7 is the minimum version used
    - Change log4j and slf4j so that Java melody can be more easily added on top.

Changes to the web-ui submodule are minimal, because the assumption is that customizations can be accomplished using the WAR overlay technique supported by the `maven-war-plugin`.   This provides an ideal method for down-stream users to leverage Lodestar.   https://github.com/HHS/meshrdf contains an example in the `webui` directory of the `feature/lodestar-overlay` branch.