### PR TITLE
Change Lodestar to support CI/CD at NLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Lodestar
-========
+= Lodestar
 
 Lodestar is a Linked Data Browser and SPARQL endpoint. Lodestar is a Java based web app that can wrap any existing SPARQL endpoint to provide a set of additional SPARQL and Linked Data services. Lodestar was developed to provide a consistent set of SPARQL and Linked Data services across the European Bioinformatics Institute (EBI). Some of the service provided by Lodestar:
 
@@ -23,8 +22,7 @@ To see a demonstration of the Lodestar linked data browser please see the [Expre
 
 Documentation and stable release at http://www.ebi.ac.uk/fgpt/sw/lodestar.
 
-Release Notes
-=============
+== Release Notes
 
 **1.3**  15th October 2014
 * Fixed potential race condition in explorer when using a small number of connection pools

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-= Lodestar
+# Lodestar
 
 Lodestar is a Linked Data Browser and SPARQL endpoint. Lodestar is a Java based web app that can wrap any existing SPARQL endpoint to provide a set of additional SPARQL and Linked Data services. Lodestar was developed to provide a consistent set of SPARQL and Linked Data services across the European Bioinformatics Institute (EBI). Some of the service provided by Lodestar:
 
@@ -22,7 +22,7 @@ To see a demonstration of the Lodestar linked data browser please see the [Expre
 
 Documentation and stable release at http://www.ebi.ac.uk/fgpt/sw/lodestar.
 
-== Release Notes
+## Release Notes
 
 **1.3**  15th October 2014
 * Fixed potential race condition in explorer when using a small number of connection pools

--- a/lode-core-servlet/src/main/java/uk/ac/ebi/fgpt/lode/servlet/ExplorerServlet.java
+++ b/lode-core-servlet/src/main/java/uk/ac/ebi/fgpt/lode/servlet/ExplorerServlet.java
@@ -97,19 +97,39 @@ public class ExplorerServlet {
         }
     }
 
-    @RequestMapping (produces="application/rdf+n3")
+    @RequestMapping (produces="text/n3")
     public @ResponseBody
     void describeResourceAsN3 (
             @RequestParam(value = "uri", required = true ) String uri,
             HttpServletResponse response) throws IOException, LodeException {
         if (uri != null && uri.length() > 0) {
             String query = "DESCRIBE <" + URI.create(uri) + ">";
-            log.trace("querying for graph rdf+n3");
-            response.setContentType("application/rdf+n3");
+            log.trace("querying for graph n3");
+            response.setContentType("text/n3");
             ServletOutputStream out = response.getOutputStream();
             out.println();
             out.println();
             getSparqlService().query(query, "N3", false, out);
+            out.close();
+        }
+        else {
+            handleBadUriException(new Exception("Malformed or empty URI request: " + uri));
+        }
+    }
+
+    @RequestMapping (produces="text/turtle")
+    public @ResponseBody
+    void describeResourceAsTurtle (
+            @RequestParam(value = "uri", required = true ) String uri,
+            HttpServletResponse response) throws IOException, LodeException {
+        if (uri != null && uri.length() > 0) {
+            String query = "DESCRIBE <" + URI.create(uri) + ">";
+            log.trace("querying for graph turtle");
+            response.setContentType("text/turtle");
+            ServletOutputStream out = response.getOutputStream();
+            out.println();
+            out.println();
+            getSparqlService().query(query, "TURTLE", false, out);
             out.close();
         }
         else {

--- a/web-ui/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/web-ui/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -35,7 +35,7 @@
     <rule>
         <condition name="Accept" type="header" operator="notequal">text/html</condition>
         <from>/sparql$</from>
-        <to>/servlet/query$1</to>
+        <to>/servlet/query</to>
     </rule>
 
 

--- a/web-ui/src/main/webapp/explore.html
+++ b/web-ui/src/main/webapp/explore.html
@@ -16,7 +16,7 @@
 <!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en"> <![endif]-->
 <!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en"> <![endif]-->
 <!-- Consider adding an manifest.appcache: h5bp.com/d/Offline -->
-<!--[if gt IE 8]><!--> <html lang="en"> <!--<![endif]-->
+<!--[if gt IE 8]><!--> <html  class="no-js" lang="en"> <!--<![endif]-->
 
 <head>
     <title>SPARQL Explorer</title>

--- a/web-ui/src/main/webapp/scripts/lode.js
+++ b/web-ui/src/main/webapp/scripts/lode.js
@@ -449,7 +449,7 @@ function querySparql () {
 
     sparqlQueryTextArea.setValue(querytext);
 
-    var exp = /^\s*(?:PREFIX\s+\w*:\s?<[^>]*>\s*)*(\w+)\s*.*/i;
+    var exp = /^\s*(?:PREFIX\s+[^:]*:\s?<[^>]*>\s*)*(\w+)\s*.*/i;
     var match = exp.exec(querytext);
     var successFunc;
     var requestHeader;

--- a/web-ui/src/main/webapp/scripts/lode.js
+++ b/web-ui/src/main/webapp/scripts/lode.js
@@ -279,7 +279,7 @@ function _buildExplorerPage(element) {
 function _buildSparqlPage(element) {
 
 
-    var sparqlForm = $("<form id='lodestar-sparql-form' class='ui-widget ui-corner-all' name='lode-star-sparql form' action='#lodestart-sparql-results' method='GET'></form>");
+    var sparqlForm = $("<form id='lodestar-sparql-form' class='ui-widget ui-corner-all' name='lode-star-sparql form' action='#loadstar-results-section' method='GET'></form>");
     var fieldSet= $("<fieldset></fieldset>");
     fieldSet.append($("<legend>Enter SPARQL Query</legend>"));
     sparqlForm.append(fieldSet);


### PR DESCRIPTION
- Remove version number from Maven sub-modules - they should follow the parent version
- Isolate dependency on `*.ebi.ac.uk` domain names using Maven properties in parent - some need for Maven `settings.xml` changes at NLM to provide properties that work.
- Finally fix build ordering issue by making `webui` submodule depend on `lode-virtuoso-impl` when the virtuoso profile is active.